### PR TITLE
Catch errors while retrieving Bitchute videos

### DIFF
--- a/cisticola/scraper/bitchute.py
+++ b/cisticola/scraper/bitchute.py
@@ -184,7 +184,7 @@ def request_from_bitchute(session, method, url, headers=None, data=None):
                 raise NotImplemented()
 
             if request.status_code >= 300:
-                raise ValueError("Response %i from BitChut for URL %s, need to retry" % (request.status_code, url))
+                raise ValueError("Response %i from BitChute for URL %s, need to retry" % (request.status_code, url))
 
             response = request.json()
             return response
@@ -421,14 +421,8 @@ def get_videos_user(session, user, csrftoken, detail):
 
         post_data = {"csrfmiddlewaretoken": csrftoken, "name": "", "offset": str(offset)}
 
-        try:
-            request = session.post(url, data=post_data, headers=headers)
-            if request.status_code != 200:
-                raise ConnectionError()
-            response = request.json()
+        response = request_from_bitchute(session, "POST", url, headers=headers, data=post_data)
 
-        except (json.JSONDecodeError, requests.RequestException, ConnectionError) as e:
-            raise ValueError('FALSE')
         soup = BeautifulSoup(response["html"], 'html.parser')
         videos = soup.select(".channel-videos-container")
         comments = []


### PR DESCRIPTION
Made `get_videos_user` use `request_from_bitchute` requests wrapper to catch errors.

Should fix Issue https://github.com/bellingcat/cisticola/issues/35