### PR TITLE
Performance optimizations and bug fixes

### DIFF
--- a/cisticola/base.py
+++ b/cisticola/base.py
@@ -11,7 +11,7 @@ import pytesseract
 import PIL
 import exiftool
 import re
-from langdetect import detect, DetectorFactory
+from langdetect import PROFILES_DIRECTORY, DetectorFactory
 from langdetect.lang_detect_exception import LangDetectException
 from loguru import logger
 import spacy
@@ -164,6 +164,15 @@ nlp_fr = spacy.load('fr_core_news_sm', disable=['parser', 'tok2vec', 'attribute_
 nlp_ru = spacy.load('ru_core_news_sm', disable=['parser', 'tok2vec', 'attribute_ruler'])
 nlp_nl = spacy.load('nl_core_news_sm', disable=['parser', 'tok2vec', 'attribute_ruler'])
 nlp_xx = spacy.load('xx_ent_wiki_sm')
+
+factory = DetectorFactory()
+factory.load_profile(PROFILES_DIRECTORY)
+detector = factory.create()
+
+def detect(text, detector=detector):
+    detector.text = ""
+    detector.append(text)
+    return detector.detect()
 
 @dataclass
 class Post:


### PR DESCRIPTION
- Modified langdetect detect method to decrease run-time
- Fixed indentation error in `transform_info`
- Prototyped removal of offset in `transform_all_untransformed`
    - This change needs modifications: it fails for the first batch, since the `batch` is already computed, so that only one `ScraperResult.date` is greater than or equal to `max(batch, key=lambda v: v.date).date`, so only one post is transformed.
- Originally modified `TelegramTelethonTransformer` to have a `self.client` attribute, but this caused the transformer tests to fail, since having a `TelegramTelethonScraper` already initialized while initializing a `TelegramTelethonTransformer` causes the Telethon session database to be locked. This could be addressed by deleting the `controller` object in `tests/transformer/telegram_telethon.py`